### PR TITLE
Мясо гондолы для трейторов поваров

### DIFF
--- a/code/modules/uplink/uplink_items/job.dm
+++ b/code/modules/uplink/uplink_items/job.dm
@@ -57,7 +57,7 @@
 	name = "Gondola meat"
 	desc = "A slice of gondola meat will turn any hard-working, brainwashed NT employee into a goody-two-shoes gondola in a matter of minutes."
 	item = /obj/item/food/meat/slab/gondola
-	cost = 6
+	cost = 10
 	restricted_roles = list(JOB_COOK)
 
 // Low progression cost

--- a/code/modules/uplink/uplink_items/job.dm
+++ b/code/modules/uplink/uplink_items/job.dm
@@ -56,7 +56,7 @@
 /datum/uplink_item/role_restricted/gondola_meat
 	name = "Gondola meat"
 	desc = "A slice of gondola meat will turn any hard-working, brainwashed NT employee into a goody-two-shoes gondola in a matter of minutes."
-	item = /obj/item/reagent_containers/food/snacks/meat/slab/gondola
+	item = /obj/item/food/meat/slab/gondola
 	cost = 6
 	restricted_roles = list(JOB_COOK)
 

--- a/code/modules/uplink/uplink_items/job.dm
+++ b/code/modules/uplink/uplink_items/job.dm
@@ -53,6 +53,13 @@
 	restricted_roles = list(JOB_ASSISTANT)
 	surplus = 0
 
+/datum/uplink_item/role_restricted/gondola_meat
+	name = "Gondola meat"
+	desc = "A slice of gondola meat will turn any hard-working, brainwashed NT employee into a goody-two-shoes gondola in a matter of minutes."
+	item = /obj/item/reagent_containers/food/snacks/meat/slab/gondola
+	cost = 6
+	restricted_roles = list(JOB_COOK)
+
 // Low progression cost
 
 /datum/uplink_item/role_restricted/clownpin


### PR DESCRIPTION
## About The Pull Request

Позволяет трейторам поварам купить мясо гондолы(содержит реагент, заражающий людей вирусом, который через некоторое время превращает их в гондол, вирус можно вылечить) за 6 ТК

## Why It's Good For The Game

Смешной трейторский предмет с возможностью для гиммиков

## Changelog

:cl:
add: Позволяет трейторам поварам покупать мясо гондолы
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
