### PR TITLE
Позволяет ядерным оперативникам покупать высокочастотные клинки

### DIFF
--- a/code/game/objects/items/weaponry.dm
+++ b/code/game/objects/items/weaponry.dm
@@ -1114,3 +1114,19 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 		balloon_alert(user, "you're too weak!")
 		return
 	return ..()
+
+/obj/item/highfrequencyblade/nukie
+	force = 6
+	throwforce = 20
+	wound_bonus = 20
+	bare_wound_bonus = 25
+	slash_color = COLOR_RED
+
+/obj/item/highfrequencyblade/nukie/attack_self(mob/user, modifiers)
+	if(!IS_NUKE_OP(user) && !user.mind?.has_antag_datum(/datum/antagonist/traitor))
+		if(prob(5))
+			to_chat(user, span_warning("You deny your weapon its purpose! It yearns to bathe in the blood of your enemies... but you hold it back!"))
+			return
+		balloon_alert(user, "skill issue!")
+		return
+	return ..()

--- a/code/modules/uplink/uplink_items/nukeops.dm
+++ b/code/modules/uplink/uplink_items/nukeops.dm
@@ -55,6 +55,15 @@
 	surplus = 30
 	purchasable_from = UPLINK_NUKE_OPS
 
+/datum/uplink_item/dangerous/highfrequencyblade
+	name = "High Frequency Blade"
+	desc = "A sword reinforced by a powerful alternating current and resonating at extremely high vibration frequencies. \
+		This oscillation weakens the molecular bonds of anything it cuts, thereby increasing its cutting ability."
+	item = /obj/item/highfrequencyblade/nukie
+	cost = 20
+	surplus = 0
+	purchasable_from = UPLINK_NUKE_OPS
+
 /datum/uplink_item/dangerous/pie_cannon
 	name = "Banana Cream Pie Cannon"
 	desc = "A special pie cannon for a special clown, this gadget can hold up to 20 pies and automatically fabricates one every two seconds!"


### PR DESCRIPTION
## About The Pull Request

Добавляет ослабленную версию высокочастотного клинка нюкерам за 20 ТК

## Why It's Good For The Game

Крутой и стилевый предмет, альтернатива энергетическим мечам

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Ядерные оперативники могут покупать высокочастотные клинки
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
