### PR TITLE
Делает кровных братьев менее пососными

### DIFF
--- a/code/game/objects/items/storage/uplink_kits.dm
+++ b/code/game/objects/items/storage/uplink_kits.dm
@@ -607,6 +607,19 @@
 		group.register(i)
 	desc += " The implants are registered to the \"[group.name]\" group."
 
+/obj/item/storage/box/syndie_kit/c4
+
+/obj/item/storage/box/syndie_kit/c4/PopulateContents()
+	new /obj/item/grenade/c4 (src)
+	new /obj/item/grenade/c4 (src)
+	new /obj/item/grenade/c4 (src)
+
+/obj/item/storage/box/syndie_kit/syndi_keys
+
+/obj/item/storage/box/syndie_kit/syndi_keys/PopulateContents()
+	new /obj/item/encryptionkey/syndicate
+	new /obj/item/encryptionkey/syndicate
+	
 #undef KIT_RECON
 #undef KIT_BLOODY_SPAI
 #undef KIT_STEALTHY

--- a/code/modules/antagonists/brother/brother.dm
+++ b/code/modules/antagonists/brother/brother.dm
@@ -24,6 +24,7 @@
 	objectives += team.objectives
 	owner.special_role = special_role
 	finalize_brother()
+	equip_bloodbro()
 	return ..()
 
 /datum/antagonist/brother/on_removal()
@@ -84,6 +85,7 @@
 	to_chat(owner.current, span_alertsyndie("You are the [owner.special_role] of [brother_text]."))
 	to_chat(owner.current, "The Syndicate only accepts those that have proven themselves. Prove yourself and prove your [team.member_name]s by completing your objectives together!")
 	owner.announce_objectives()
+	to_chat(owner.current, "You both start with a storage implant containing one item, chosen by your employers. Use it wise!")
 	give_meeting_area()
 
 /datum/antagonist/brother/proc/finalize_brother()
@@ -170,3 +172,19 @@
 			add_objective(new /datum/objective/assassinate, needs_target = TRUE)
 	else
 		add_objective(new /datum/objective/steal, needs_target = TRUE)
+
+/datum/antagonist/brother/proc/equip_bloodbro()
+	if(!owner || !owner.current || !ishuman(owner.current))
+		return
+	var/list/possible_items = list(/obj/item/soap/syndie,/obj/item/pen/sleepy,/obj/item/pen/edagger,/obj/item/language_manual/codespeak_manual/unlimited,
+								   /obj/item/clothing/shoes/chameleon/noslip, /obj/item/storage/box/syndie_kit/c4,
+								   /obj/item/storage/box/syndie_kit/throwing_weapons, /obj/item/gun/ballistic/automatic/c20r/toy, /obj/item/storage/box/syndie_kit/emp,
+								   /obj/item/card/id/advanced/chameleon, /obj/item/multitool/ai_detect, /obj/item/storage/box/syndie_kit/chameleon,
+								   /obj/item/card/emag, /obj/item/card/emag/doorjack,/obj/item/storage/box/syndie_kit/syndi_keys, /obj/item/jammer,)
+	var/obj/item/implant/storage/S = locate(/obj/item/implant/storage) in owner.current
+	if(!S)
+		S = new(owner.current)
+		S.implant(owner.current)
+	var/I = pick(possible_items)
+	if(ispath(I))
+		I = new I(S)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Кровные братья теперь стартуют с storage implant, в котором будет находиться случайный дешевый стелс-ориентированый трейторский предмет

## Why It's Good For The Game

Кровные братья это пососный антаг, на котором никто не хочет играть. Этот ПР делает их более прикольными.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Кровные братья стартуют со сторейдж имплантом, в котором будет находиться случайный дешевый трейторский предмет
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
