### PR TITLE
Баллистика для народа

### DIFF
--- a/code/modules/cargo/goodies.dm
+++ b/code/modules/cargo/goodies.dm
@@ -87,6 +87,20 @@
 	access_view = ACCESS_WEAPONS
 	contains = list(/obj/item/storage/belt/holster/energy/thermal)
 
+/datum/supply_pack/goody/wt550_single
+	name = "WT-550 Auto Rifle Single-Pack"
+	desc = "Contains one high-powered, semiautomatic rifles chambered in 4.6x30mm." // "high-powered" lol yea right
+	cost = PAYCHECK_CREW * 20
+	access_view = ACCESS_WEAPONS
+	contains = list(/obj/item/gun/ballistic/automatic/wt550)
+
+/datum/supply_pack/goody/wt550ammo_single
+	name = "WT-550 Auto Rifle Ammo Single-Pack"
+	desc = "Contains a 20-round magazine for the WT-550 Auto Rifle. Each magazine is designed to facilitate rapid tactical reloads."
+	cost = PAYCHECK_CREW * 6
+	access_view = ACCESS_WEAPONS
+	contains = list(/obj/item/ammo_box/magazine/wt550m9)
+
 /datum/supply_pack/goody/sologamermitts
 	name = "Insulated Gloves Single-Pack"
 	desc = "The backbone of modern society. Barely ever ordered for actual engineering."

--- a/code/modules/cargo/packs/security.dm
+++ b/code/modules/cargo/packs/security.dm
@@ -347,24 +347,21 @@
 	crate_name = "thermal pistol crate"
 
 /datum/supply_pack/security/armory/wt550
-	name = "Recalled Weapon Pack"
-	desc = "Contains a set of old Nanotrasen brand autorifles recalled due to choking hazard."
+	name = "WT-550 Auto Rifle Crate"
+	desc = "Contains two high-powered, semiautomatic rifles chambered in 4.6x30mm. Requires Armory access to open."
 	cost = CARGO_CRATE_VALUE * 7
-	hidden = TRUE
 	contains = list(
 		/obj/item/gun/ballistic/automatic/wt550 = 2,
 		/obj/item/ammo_box/magazine/wt550m9 = 2,
 	)
-	crate_name = "Recalled rifle crate"
+	crate_name = "wt-550 auto rifle crate"
 
 /datum/supply_pack/security/armory/wt550ammo
-	name = "Recalled Ammo Pack"
-	desc = "Contains four 20-round magazine for the Recalled WT-550 Auto Rifle. \
-	Each magazine is designed to facilitate rapid tactical reloads. Recalled due to Security demands."
+	name = "WT-550 Standard Ammo Crate"
+	desc = "Contains four 20-round magazine for the WT-550 Auto Rifle. Each magazine is designed to facilitate rapid tactical reloads. Requires Armory access to open."
 	cost = CARGO_CRATE_VALUE * 4
-	hidden = TRUE
 	contains = list(
 		/obj/item/ammo_box/magazine/wt550m9 = 4,
 	)
-	crate_name = "Ammo box"
+	crate_name = "wt-550 standard ammo crate"
 

--- a/code/modules/research/designs/weapon_designs.dm
+++ b/code/modules/research/designs/weapon_designs.dm
@@ -319,6 +319,34 @@
 	)
 	departmental_flags = DEPARTMENT_BITFLAG_SCIENCE
 
+//WT550 Mags
+
+/datum/design/mag_oldsmg
+	name = "WT-550 Auto Gun Magazine (4.6x30mm)"
+	desc = "A 20 round magazine for the out of date security WT-550 Auto Rifle"
+	id = "mag_oldsmg"
+	build_type = PROTOLATHE | AWAY_LATHE
+	materials = list(/datum/material/iron = 4000)
+	build_path = /obj/item/ammo_box/magazine/wt550m9
+	category = list("Ammo")
+	departmental_flags = DEPARTMENT_BITFLAG_SECURITY
+
+/datum/design/mag_oldsmg/ap_mag
+	name = "WT-550 Auto Gun Armour Piercing Magazine (4.6x30mm AP)"
+	desc = "A 20 round armour piercing magazine for the out of date security WT-550 Auto Rifle"
+	id = "mag_oldsmg_ap"
+	materials = list(/datum/material/iron = 6000, /datum/material/silver = 600)
+	build_path = /obj/item/ammo_box/magazine/wt550m9/wtap
+	departmental_flags = DEPARTMENT_BITFLAG_SECURITY
+
+/datum/design/mag_oldsmg/ic_mag
+	name = "WT-550 Auto Gun Incendiary Magazine (4.6x30mm IC)"
+	desc = "A 20 round armour piercing magazine for the out of date security WT-550 Auto Rifle"
+	id = "mag_oldsmg_ic"
+	materials = list(/datum/material/iron = 6000, /datum/material/silver = 600, /datum/material/glass = 1000)
+	build_path = /obj/item/ammo_box/magazine/wt550m9/wtic
+	departmental_flags = DEPARTMENT_BITFLAG_SECURITY
+
 /datum/design/stunshell
 	name = "Stun Shell"
 	desc = "A stunning shell for a shotgun."

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -1574,6 +1574,18 @@
 	)
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
 
+/datum/techweb_node/ballistic_weapons
+	id = "ballistic_weapons"
+	display_name = "Ballistic Weaponry"
+	description = "This isn't research.. This is reverse-engineering!"
+	prereq_ids = list("weaponry")
+	design_ids = list(
+		"mag_oldsmg",
+		"mag_oldsmg_ap",
+		"mag_oldsmg_ic",
+	)
+	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
+
 /datum/techweb_node/exotic_ammo
 	id = "exotic_ammo"
 	display_name = "Exotic Ammunition"
@@ -1895,7 +1907,7 @@
 	id = "mecha_tools"
 	display_name = "Exosuit Weapon (LBX AC 10 \"Scattershot\")"
 	description = "An advanced piece of mech weaponry"
-	prereq_ids = list("adv_mecha")
+	prereq_ids = list("adv_mecha", "ballistic_weapons")
 	design_ids = list(
 		"mech_scattershot",
 		"mech_scattershot_ammo",
@@ -1906,7 +1918,7 @@
 	id = "mech_carbine"
 	display_name = "Exosuit Weapon (FNX-99 \"Hades\" Carbine)"
 	description = "An advanced piece of mech weaponry"
-	prereq_ids = list("exotic_ammo")
+	prereq_ids = list("exotic_ammo", "ballistic_weapons")
 	design_ids = list(
 		"mech_carbine",
 		"mech_carbine_ammo",


### PR DESCRIPTION
## About The Pull Request

Реверт https://github.com/tgstation/tgstation/pull/64280 (новое оружие введенное там все еще остаеться)

Позволяет снова покупать через карго WT-550 без требования к емагу, а так же возвращает обратно исследование "Ballistic Weapons", позволяющее при исследовании делать WT-550 через секьюрити протолат.

## Why It's Good For The Game

Баллистическое оружие гораздо более эстетическое и приятное в использовании, этот ПР позволяет людям опять насладиться возможностью использовать нормальное оружие, а не скучные лазеры.

## Changelog

:cl:
add: WT-550 можно теперь покупать в карго без емагнутой консоли
add: Исследование баллистического оружия добавленно обратно для R&D
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
