### PR TITLE
remove TRAIT_CHUNKYFINGERS from gloves

### DIFF
--- a/code/modules/clothing/gloves/special.dm
+++ b/code/modules/clothing/gloves/special.dm
@@ -6,7 +6,6 @@
 	greyscale_colors = "#2f2e31"
 	equip_delay_self = 3 SECONDS
 	equip_delay_other = 4 SECONDS
-	clothing_traits = list(TRAIT_CHUNKYFINGERS)
 	undyeable = TRUE
 	var/datum/weakref/pull_component_weakref
 
@@ -141,5 +140,5 @@
 	max_heat_protection_temperature = FIRE_IMMUNITY_MAX_TEMP_PROTECT
 	resistance_flags = FIRE_PROOF
 	siemens_coefficient = 0.3
-	clothing_traits = list(TRAIT_QUICKER_CARRY, TRAIT_CHUNKYFINGERS)
+	clothing_traits = list(TRAIT_QUICKER_CARRY)
 	clothing_flags = THICKMATERIAL


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Убирает TRAIT_CHUNKYFINGERS с перчаток карго и атмосферики

## Why It's Good For The Game

Если убрали с изолек, то хоршо убрать и с других перчаток, чтобы избежать skill ussue моментов

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
del: Removed TRAIT_CHUNKYFINGERS from atmospheric extrication gloves
del: Removed TRAIT_CHUNKYFINGERS from H.A.U.L. gauntlets
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
