### PR TITLE
Позволяет покупать ураниум через карго

### DIFF
--- a/code/game/objects/items/stacks/sheets/mineral.dm
+++ b/code/game/objects/items/stacks/sheets/mineral.dm
@@ -142,6 +142,9 @@ GLOBAL_LIST_INIT(uranium_recipes, list ( \
 /obj/item/stack/sheet/mineral/uranium/five
 	amount = 5
 
+/obj/item/stack/sheet/mineral/uranium/twenty
+	amount = 20
+
 /*
  * Plasma
  */

--- a/code/modules/cargo/packs/materials.dm
+++ b/code/modules/cargo/packs/materials.dm
@@ -51,6 +51,14 @@
 	contains = list(/obj/item/stack/sheet/plastic/fifty)
 	crate_name = "plastic sheets crate"
 
+/datum/supply_pack/materials/uranium20
+	name = "20 Uranium Sheets"
+	desc = "For your unethical experiments."
+	cost = CARGO_CRATE_VALUE * 6
+	contains = list(/obj/item/stack/sheet/mineral/uranium/twenty)
+	crate_name = "uranium crate"
+	contraband = TRUE
+
 /datum/supply_pack/materials/sandstone30
 	name = "30 Sandstone Blocks"
 	desc = "Neither sandy nor stoney, these thirty blocks will still get the job done."


### PR DESCRIPTION
## About The Pull Request

Позволяет покупать 20 ураниума за 1200 очков на взломанной консоли

## Why It's Good For The Game

Надеятся на майнеров не особо прикольно, очень часто их либо просто нету либо они все умерли, в результате чего ты не можешь делать свою работу и твой раунд заруинен

## Changelog

:cl:
add: Можно покупать ураниум через взломанную карго консоль
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
