### PR TITLE
Stealthy North Star

### DIFF
--- a/code/game/objects/structures/mystery_box.dm
+++ b/code/game/objects/structures/mystery_box.dm
@@ -54,7 +54,7 @@ GLOBAL_LIST_INIT(mystery_box_guns, list(
 GLOBAL_LIST_INIT(mystery_box_extended, list(
 	/obj/item/clothing/gloves/tackler/combat,
 	/obj/item/clothing/gloves/race,
-	/obj/item/clothing/gloves/rapid,
+	/obj/item/clothing/gloves/chameleon/rapid,
 	/obj/item/shield/riot/flash,
 	/obj/item/grenade/stingbang/mega,
 	/obj/item/storage/belt/sabre,

--- a/code/modules/clothing/gloves/special.dm
+++ b/code/modules/clothing/gloves/special.dm
@@ -55,7 +55,7 @@
 	inhand_icon_state = null
 	clothing_traits = list(TRAIT_FINGERPRINT_PASSTHROUGH)
 
-/obj/item/clothing/gloves/chameleon/Initialize(mapload)
+/obj/item/clothing/gloves/chameleon/rapid/Initialize(mapload)
 	. = ..()
 	AddComponent(/datum/component/wearertargeting/punchcooldown)
 

--- a/code/modules/clothing/gloves/special.dm
+++ b/code/modules/clothing/gloves/special.dm
@@ -48,14 +48,14 @@
 
 	QDEL_NULL(pull_component_weakref)
 
-/obj/item/clothing/gloves/rapid
+/obj/item/clothing/gloves/chameleon/rapid
 	name = "Gloves of the North Star"
 	desc = "Just looking at these fills you with an urge to beat the shit out of people."
 	icon_state = "rapid"
 	inhand_icon_state = null
 	clothing_traits = list(TRAIT_FINGERPRINT_PASSTHROUGH)
 
-/obj/item/clothing/gloves/rapid/Initialize(mapload)
+/obj/item/clothing/gloves/chameleon/Initialize(mapload)
 	. = ..()
 	AddComponent(/datum/component/wearertargeting/punchcooldown)
 

--- a/code/modules/uplink/uplink_items/dangerous.dm
+++ b/code/modules/uplink/uplink_items/dangerous.dm
@@ -58,7 +58,7 @@
 /datum/uplink_item/dangerous/rapid
 	name = "Gloves of the North Star"
 	desc = "These gloves let the user punch people very fast. Does not improve weapon attack speed or the meaty fists of a hulk."
-	item = /obj/item/clothing/gloves/rapid
+	item = /obj/item/clothing/gloves/chameleon/rapid
 	cost = 8
 
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Позволяет менять нортстарам внешность, как у хамелеон перчаток

## Why It's Good For The Game

Нортстары сами по себе слабая вещь, особенно по сравнению с есвордом за те же 8 телекристалов (больше разового урона + блок 50%), так ещё и говорит каждому осмотревшему что ты антаг. Сделает использование нортстаров как дополнительно инструмента атаки или добивания куда приятнее.

## Changelog

:cl:
add: North Star gloves are chemelions
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
