### PR TITLE
Нелетальные пули для ВТ-550

### DIFF
--- a/code/modules/cargo/packs/security.dm
+++ b/code/modules/cargo/packs/security.dm
@@ -365,3 +365,13 @@
 	)
 	crate_name = "wt-550 standard ammo crate"
 
+/datum/supply_pack/security/armory/wt550rubberammo
+	name = "WT-550 Rubber Ammo Crate"
+	desc = "Contains four 20-round magazine with rubber ammo for the WT-550 Auto Rifle. Each magazine is designed to facilitate rapid tactical reloads. Requires Armory access to open."
+	cost = CARGO_CRATE_VALUE * 3.5
+	contains = list(
+		/obj/item/ammo_box/magazine/wt550m9/rubber = 4,
+	)
+	crate_name = "wt-550 rubber ammo crate"
+
+

--- a/code/modules/projectiles/ammunition/ballistic/smg.dm
+++ b/code/modules/projectiles/ammunition/ballistic/smg.dm
@@ -16,6 +16,11 @@
 	desc = "A 4.6x30mm incendiary bullet casing."
 	projectile_type = /obj/projectile/bullet/incendiary/c46x30mm
 
+/obj/item/ammo_casing/c46x30mm/nonlethal
+	name = "4.6x30mm rubber bullet casing"
+	desc = "A 4.6x30mm rubber bullet casing."
+	projectile_type = /obj/projectile/bullet/c46x30mm/nonlethal
+
 // .45 (M1911 + C20r)
 
 /obj/item/ammo_casing/c45

--- a/code/modules/projectiles/boxes_magazines/external/smg.dm
+++ b/code/modules/projectiles/boxes_magazines/external/smg.dm
@@ -30,6 +30,12 @@
 	. = ..()
 	icon_state = "[base_icon_state]-[round(ammo_count(), 4)]"
 
+/obj/item/ammo_box/magazine/wt550m9/rubber
+	name = "wt550 magazine (Rubber 4.6x30mm)"
+	icon_state = "46x30mmt-20"
+	base_icon_state = "46x30mmt"
+	ammo_type = /obj/item/ammo_casing/c46x30mm/nonlethal
+
 /obj/item/ammo_box/magazine/plastikov9mm
 	name = "PP-95 magazine (9mm)"
 	icon_state = "9x19-50"

--- a/code/modules/projectiles/projectile/bullets/smg.dm
+++ b/code/modules/projectiles/projectile/bullets/smg.dm
@@ -30,6 +30,12 @@
 	armour_penetration = 40
 	embedding = null
 
+/obj/projectile/bullet/c46x30mm/nonlethal
+	name = "4.6x30mm rubber bullet"
+	damage = 5
+	stamina = 20
+	embedding = null
+
 /obj/projectile/bullet/incendiary/c46x30mm
 	name = "4.6x30mm incendiary bullet"
 	damage = 10

--- a/code/modules/research/designs/weapon_designs.dm
+++ b/code/modules/research/designs/weapon_designs.dm
@@ -347,6 +347,14 @@
 	build_path = /obj/item/ammo_box/magazine/wt550m9/wtic
 	departmental_flags = DEPARTMENT_BITFLAG_SECURITY
 
+/datum/design/mag_oldsmg/ic_mag
+	name = "WT-550 Auto Gun Rubber Magazine (4.6x30mm NL)"
+	desc = "A 20 round rubber bullet magazine for the out of date security WT-550 Auto Rifle"
+	id = "mag_oldsmg_rub"
+	materials = list(/datum/material/iron = 3500)
+	build_path = /obj/item/ammo_box/magazine/wt550m9/rubber
+	departmental_flags = DEPARTMENT_BITFLAG_SECURITY
+
 /datum/design/stunshell
 	name = "Stun Shell"
 	desc = "A stunning shell for a shotgun."

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -1583,6 +1583,7 @@
 		"mag_oldsmg",
 		"mag_oldsmg_ap",
 		"mag_oldsmg_ic",
+		"mag_oldsmg_rub",
 	)
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
 


### PR DESCRIPTION
## About The Pull Request

Добавляет альтернативные нелетальные пули для ВТ-550

## Why It's Good For The Game

Компромисс между использованием скучных дизейблеров и превращением вашего опонента в решето

## Changelog

:cl:
add: Нелетальные резиновые пули для ВТ-550, могут быть куплены в карго или изготовлены после исследования технологии Ballistic Weponry
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
