### PR TITLE
НЕРФ БАТОНА!! НЕРФ БАТОНА!! ТГ КОДЕР АЛЯРМ

### DIFF
--- a/code/game/objects/items/melee/baton.dm
+++ b/code/game/objects/items/melee/baton.dm
@@ -197,7 +197,7 @@
 		target.Paralyze((isnull(stun_override) ? stun_time_cyborg : stun_override) * (trait_check ? 0.1 : 1))
 		additional_effects_cyborg(target, user)
 	else
-		target.apply_damage(stamina_damage, STAMINA)
+		addtimer(CALLBACK(target, TYPE_PROC_REF(/mob/living, apply_damage), stamina_damage, STAMINA), 0.2 SECONDS)
 		if(!trait_check)
 			target.Knockdown((isnull(stun_override) ? knockdown_time : stun_override))
 		additional_effects_non_cyborg(target, user)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Добавляет задержу в нанесение стаминурона батонами в размере 0.2 секунды

## Why It's Good For The Game

Ну поехали
![image](https://user-images.githubusercontent.com/52973135/223845451-ae4013b4-7f68-4797-8159-248ed07d54b4.png)
Задача: на картинке вы видите двух чурок, бьющих друг друга батонами в один момент временя. Вопрос. Кто кого отпиздит?
Ответ: оба получат по ебалу и получат по 60 стамина урона и через 1 секунду упадут в кнокдаун на  5 секунд


![image](https://user-images.githubusercontent.com/52973135/223846467-a69fc7d2-477c-4a5a-b27e-88f2e816f413.png)
Задача№2: чурки ёбнули друг дружку батонами и прошло 2.5 секунд (время между ударами батоном), и они опять ударяют друг друга в один момент времени. Вопрос. Кто кого отпиздит?
Ответ: Хуй его знает, в зависимости от того как сложатся звёзды на небесах. Но в данном случае один из них не получит удар, а второй упадёт в стамин крит

С введением этого пиара задача №2 будет иметь очевидный ответ - оба упадут в стаминкрит после параллельных ударов.
По моему мнению такое поведение будет куда занимательнее и сделает боёвку опаснее и интересней, уменьшит рандом при одновременных ударах (если такое вообще случается)



## Changelog

:cl:
add: Baton staminadamage delay
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
