### PR TITLE
Вассалы теперь сообщаються в раунденде

### DIFF
--- a/massmeta/code/modules/antagonists/bloodsuckers/bloodsucker/bloodsucker_datum.dm
+++ b/massmeta/code/modules/antagonists/bloodsuckers/bloodsucker/bloodsucker_datum.dm
@@ -430,3 +430,37 @@
 			gourmand_objective.owner = owner
 			gourmand_objective.objective_name = "Optional Objective"
 			objectives += gourmand_objective
+
+/datum/antagonist/bloodsucker/roundend_report()
+	// Get the default Objectives
+	var/list/report = list()
+	// Vamp name
+	report += "<br><span class='header'><b>\[[return_full_name()]\]</b></span>"
+	report += printplayer(owner)
+	// Clan (Actual Clan, not Team) name
+	if(my_clan != NONE)
+		report += "They were part of the <b>[my_clan]</b>!"
+
+	// Default Report
+	var/objectives_complete = TRUE
+	if(objectives.len)
+		report += printobjectives(objectives)
+		for(var/datum/objective/objective in objectives)
+			if(!objective.check_completion())
+				objectives_complete = FALSE
+				break
+
+	// Now list their vassals
+	if(vassals.len > 0)
+		report += "<span class='header'>Their Vassals were...</span>"
+		for(var/datum/antagonist/vassal/all_vassals in vassals)
+			if(all_vassals.owner)
+				var/jobname = all_vassals.owner.assigned_role ? "the [all_vassals.owner.assigned_role.name]" : ""
+				report += "<b>[all_vassals.owner.name]</b> [jobname] was a [all_vassals.name]"
+
+	if(objectives.len == 0 || objectives_complete)
+		report += "<span class='greentext big'>The [name] was successful!</span>"
+	else
+		report += "<span class='redtext big'>The [name] has failed!</span>"
+
+	return report

--- a/massmeta/code/modules/antagonists/bloodsuckers/bloodsucker/bloodsucker_datum.dm
+++ b/massmeta/code/modules/antagonists/bloodsuckers/bloodsucker/bloodsucker_datum.dm
@@ -455,7 +455,7 @@
 		report += "<span class='header'>Their Vassals were...</span>"
 		for(var/datum/antagonist/vassal/all_vassals in vassals)
 			if(all_vassals.owner)
-				var/jobname = all_vassals.owner.assigned_role ? "the [all_vassals.owner.assigned_role.name]" : ""
+				var/jobname = all_vassals.owner.assigned_role ? "the [all_vassals.owner.assigned_role.title]" : ""
 				report += "<b>[all_vassals.owner.name]</b> [jobname] was a [all_vassals.name]"
 
 	if(objectives.len == 0 || objectives_complete)


### PR DESCRIPTION
## About The Pull Request

В раунденде теперь сообщаеться вассалы, которые были у вампиров

## Why It's Good For The Game

Вассалы не будут забыты

## Changelog

:cl:
add: В раунденде теперь сообщаються кто были вассалами вампиров
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
