### PR TITLE
Фиксы даркспаунов

### DIFF
--- a/massmeta/code/modules/antagonists/darkspawn/darkspawn_species.dm
+++ b/massmeta/code/modules/antagonists/darkspawn/darkspawn_species.dm
@@ -11,6 +11,7 @@
 	no_equip_flags = ITEM_SLOT_HEAD | ITEM_SLOT_MASK | ITEM_SLOT_OCLOTHING | ITEM_SLOT_GLOVES | ITEM_SLOT_FEET | ITEM_SLOT_ICLOTHING | ITEM_SLOT_SUITSTORE
 	species_traits = list(NO_UNDERWEAR,NO_DNA_COPY,NOTRANSSTING,NOEYESPRITES)
 	inherent_traits = list(
+		TRAIT_GENELESS,
 		TRAIT_ADVANCEDTOOLUSER,
 		TRAIT_CAN_STRIP,
 		TRAIT_RESISTCOLD,
@@ -50,7 +51,7 @@
 /datum/species/darkspawn/spec_life(mob/living/carbon/human/H)
 	handle_upgrades(H)
 	var/turf/T = H.loc
-	if(istype(T))
+	if(istype(T) && H.stat != DEAD)
 		var/light_amount = T.get_lumcount()
 		if(light_amount < DARKSPAWN_DIM_LIGHT) //rapid healing and stun reduction in the darkness
 			var/healing_amount = DARKSPAWN_DARK_HEAL


### PR DESCRIPTION
## About The Pull Request

У даркспаунов теперь нету генов.

Даркспауны теперь не получают урон от света пока мертвы.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Даркспауны теперь не получают урон от света пока мертвы
fix: У даркспаунов теперь нету генов
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
