### PR TITLE
Дает даркспаунам еще больше защиты

### DIFF
--- a/massmeta/code/modules/antagonists/darkspawn/darkspawn_species.dm
+++ b/massmeta/code/modules/antagonists/darkspawn/darkspawn_species.dm
@@ -6,7 +6,7 @@
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_PRIDE
 	siemens_coeff = 0
 	brutemod = 0.6
-	burnmod = 0.9
+	burnmod = 0.8
 	heatmod = 1.5
 	no_equip_flags = ITEM_SLOT_HEAD | ITEM_SLOT_MASK | ITEM_SLOT_OCLOTHING | ITEM_SLOT_GLOVES | ITEM_SLOT_FEET | ITEM_SLOT_ICLOTHING | ITEM_SLOT_SUITSTORE
 	species_traits = list(NO_UNDERWEAR,NO_DNA_COPY,NOTRANSSTING,NOEYESPRITES)


### PR DESCRIPTION
## About The Pull Request

Даркспауны теперь получают на 10% урона от огня меньше чем раньше. 

:cl:
balance: Даркспауны теперь получают 80% урона от ожогов вместо 90%
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
