### PR TITLE
Баланс и QoL даркспаунов

### DIFF
--- a/code/datums/status_effects/buffs.dm
+++ b/code/datums/status_effects/buffs.dm
@@ -637,7 +637,7 @@
 		return
 	darkspawn.use_psi(5)
 
-/atom/movable/screen/alert/creep
+/atom/movable/screen/alert/status_effect/creep
 	name = "Creep"
 	desc = "You are immune to lightburn. Drains 1 Psi per second."
 	icon = 'massmeta/icons/mob/actions/actions_darkspawn.dmi'
@@ -668,8 +668,8 @@
 /atom/movable/screen/alert/status_effect/shadow_dance
 	name = "Shadow Dance"
 	desc = "You are able to avoid projectiles while in darkness."
-	button_icon = 'icons/mob/actions/actions_minor_antag.dmi'
-	button_icon_state = "ninja_cloak"
+	icon = 'icons/mob/actions/actions_minor_antag.dmi'
+	icon_state = "ninja_cloak"
 
 #define TIME_DILATION_TRAIT "time_dilation_trait"
 /datum/status_effect/time_dilation //used by darkspawn; greatly increases action times etc

--- a/code/datums/status_effects/buffs.dm
+++ b/code/datums/status_effects/buffs.dm
@@ -615,7 +615,7 @@
 /datum/status_effect/creep //allows darkspawn to move through lights without lightburn damage //Massmeta edit start
 	id = "creep"
 	duration = -1
-	alert_type = /obj/screen/alert/status_effect/creep
+	alert_type = /atom/movable/screen/alert/status_effect/creep
 	var/datum/antagonist/darkspawn/darkspawn
 
 /datum/status_effect/creep/get_examine_text()
@@ -637,17 +637,45 @@
 		return
 	darkspawn.use_psi(5)
 
-/obj/screen/alert/status_effect/creep
+/atom/movable/screen/alert/creep
 	name = "Creep"
 	desc = "You are immune to lightburn. Drains 1 Psi per second."
 	icon = 'massmeta/icons/mob/actions/actions_darkspawn.dmi'
 	icon_state = "creep"
 
+/datum/status_effect/shadow_dance //allows darkspawn to move through lights without lightburn damage //Massmeta edit start
+	id = "shadowdance"
+	duration = -1
+	alert_type = /atom/movable/screen/alert/status_effect/shadow_dance
+	var/datum/antagonist/darkspawn/darkspawn
+
+/datum/status_effect/shadow_dance/on_creation(mob/living/owner, datum/antagonist/darkspawn)
+	. = ..()
+	if(!.)
+		return
+	src.darkspawn = darkspawn
+
+/datum/status_effect/shadow_dance/tick()
+	if(!darkspawn)
+		qdel(src)
+		return
+	if(!darkspawn.has_psi(5))
+		to_chat(owner, "<span class='warning'>You dont have enough psi to mantain the dance!</span>")
+		qdel(src)
+		return
+	darkspawn.use_psi(5)
+
+/atom/movable/screen/alert/status_effect/shadow_dance
+	name = "Shadow Dance"
+	desc = "You are able to avoid projectiles while in darkness."
+	button_icon = 'icons/mob/actions/actions_minor_antag.dmi'
+	button_icon_state = "ninja_cloak"
+
 #define TIME_DILATION_TRAIT "time_dilation_trait"
 /datum/status_effect/time_dilation //used by darkspawn; greatly increases action times etc
 	id = "time_dilation"
 	duration = 600
-	alert_type = /obj/screen/alert/status_effect/time_dilation
+	alert_type = /atom/movable/screen/alert/status_effect/time_dilation
 
 /datum/status_effect/time_dilation/get_examine_text()
 	return span_warning("[owner.p_they(TRUE)] is moving jerkily and unpredictably!")
@@ -663,7 +691,7 @@
 	owner.remove_movespeed_modifier(/datum/movespeed_modifier/status_effect/time_dilation)
 	owner.remove_actionspeed_modifier(/datum/actionspeed_modifier/time_dilation)
 
-/obj/screen/alert/status_effect/time_dilation
+/atom/movable/screen/alert/status_effect/time_dilation
 	name = "Time Dilation"
 	desc = "Your actions are twice as fast, and the delay between them is halved."
 	icon = 'massmeta/icons/mob/actions/actions_darkspawn.dmi'

--- a/massmeta/code/modules/antagonists/darkspawn/crawling_shadows.dm
+++ b/massmeta/code/modules/antagonists/darkspawn/crawling_shadows.dm
@@ -14,6 +14,12 @@
 	maxHealth = 125
 	health = 125
 
+	lighting_cutoff_red = 20
+	lighting_cutoff_green = 10
+	lighting_cutoff_blue = 40
+
+	sight = = SEE_MOBS
+
 	harm_intent_damage = 5
 	obj_damage = 50
 	melee_damage_lower = 5 //it has a built in stun if you want to kill someone kill them like a man

--- a/massmeta/code/modules/antagonists/darkspawn/crawling_shadows.dm
+++ b/massmeta/code/modules/antagonists/darkspawn/crawling_shadows.dm
@@ -18,7 +18,7 @@
 	lighting_cutoff_green = 10
 	lighting_cutoff_blue = 40
 
-	sight = = SEE_MOBS
+	sight = SEE_MOBS
 
 	harm_intent_damage = 5
 	obj_damage = 50

--- a/massmeta/code/modules/antagonists/darkspawn/darkspawn_abilities/shadow_dance.dm
+++ b/massmeta/code/modules/antagonists/darkspawn/darkspawn_abilities/shadow_dance.dm
@@ -1,0 +1,30 @@
+//Allows you to move through light unimpeded while active. Drains 5 Psi per second.
+/datum/action/innate/darkspawn/shadow_dance
+	name = "Shadow Dance"
+	id = "shadowdance"
+	desc = "Allows you to avoid projectiles while in darkness. Can be toggled on and off. Drains 5 Psi per second."
+	button_icon = 'icons/mob/actions/actions_minor_antag.dmi'
+	button_icon_state = "ninja_cloak"
+	check_flags = AB_CHECK_INCAPACITATED|AB_CHECK_CONSCIOUS
+	psi_cost = 10
+	psi_addendum = " to activate and 5 per second"
+	lucidity_price = 2
+
+/datum/action/innate/darkspawn/shadow_dance/IsAvailable(feedback = FALSE)
+	if(istype(owner, /mob/living/simple_animal/hostile/crawling_shadows))
+		return
+	return ..()
+
+/datum/action/innate/darkspawn/shadow_dance/process()
+	var/mob/living/L = owner
+	active = L.has_status_effect(/datum/status_effect/shadow_dance)
+
+/datum/action/innate/darkspawn/shadow_dance/Activate()
+	var/mob/living/L = owner
+	playsound(owner, 'massmeta/sounds/magic/devour_will_victim.ogg', 50, TRUE)
+	L.apply_status_effect(/datum/status_effect/shadow_dance, darkspawn)
+
+/datum/action/innate/darkspawn/shadow_dance/Deactivate()
+	var/mob/living/L = owner
+	playsound(owner, 'massmeta/sounds/magic/devour_will_end.ogg', 50, TRUE)
+	L.remove_status_effect(/datum/status_effect/shadow_dance)

--- a/massmeta/code/modules/antagonists/darkspawn/darkspawn_species.dm
+++ b/massmeta/code/modules/antagonists/darkspawn/darkspawn_species.dm
@@ -81,6 +81,16 @@
 				H.playsound_local(H, 'sound/weapons/sear.ogg', max(30, 50 * light_amount), TRUE)
 				H.adjustFireLoss(DARKSPAWN_LIGHT_BURN * 0.5)
 
+/datum/species/darkspawn/bullet_act(obj/projectile/P, mob/living/carbon/human/H)
+	var/turf/T = H.loc
+	if(istype(T))
+		var/light_amount = T.get_lumcount()
+		if(light_amount < SHADOW_SPECIES_LIGHT_THRESHOLD && H.has_status_effect(/datum/status_effect/shadow_dance))
+			H.visible_message(span_danger("[H] dances in the shadows, evading [P]!"))
+			playsound(T, SFX_BULLET_MISS, 75, TRUE)
+			return BULLET_ACT_FORCE_PIERCE
+	return ..()
+
 /datum/species/darkspawn/spec_death(gibbed, mob/living/carbon/human/H)
 	playsound(H, 'massmeta/sounds/creatures/darkspawn_death.ogg', 50, FALSE)
 

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -5220,6 +5220,7 @@
 #include "massmeta\code\modules\antagonists\darkspawn\darkspawn_abilities\creep.dm"
 #include "massmeta\code\modules\antagonists\darkspawn\darkspawn_abilities\demented_outburst.dm"
 #include "massmeta\code\modules\antagonists\darkspawn\darkspawn_abilities\devour_will.dm"
+#include "massmeta\code\modules\antagonists\darkspawn\darkspawn_abilities\shadow_dance.dm"
 #include "massmeta\code\modules\antagonists\darkspawn\darkspawn_abilities\pass.dm"
 #include "massmeta\code\modules\antagonists\darkspawn\darkspawn_abilities\silver_tongue.dm"
 #include "massmeta\code\modules\antagonists\darkspawn\darkspawn_abilities\simulacrum.dm"


### PR DESCRIPTION
## About The Pull Request

Моб Crawling Shadows теперь может видеть в тени и имеет термальное зрение

Тентакли даркспаунов теперь не пропадают после дальней атаки тентаклей, но имеют кулдаун на нее в 2 секунды.

Броски тентаклей даркспаунов(врага на себя, и броски себя) теперь кидают "аккуратно", т.е. не могут вбить цель в стену или в другое существо.

Новая способность - танец теней, позволяет уворачиваться от пуль пока в темноте.

Теперь по идее статус эффекты даркспаунов должны иметь иконку.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Способность Танец Теней для даркспаунов
balance: Баффнуты некоторые абилки даркспаунов
fix: Теперь у статус эффектов даркспаунов должны быть иконки
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
