### PR TITLE
Меняет как работает ЕМП по робо конечностям

### DIFF
--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -497,23 +497,48 @@
 				to_chat(src, span_notice("You feel your heart beating again!"))
 	electrocution_animation(40)
 
+#define EMP_BRUTE_DAMAGE 0
+#define EMP_BURN_DAMAGE_LIGHT 2
+#define EMP_BURN_DAMAGE_HEAVY 5
+
 /mob/living/carbon/human/emp_act(severity)
 	. = ..()
 	if(. & EMP_PROTECT_CONTENTS)
 		return
 	var/informed = FALSE
-	for(var/obj/item/bodypart/L as anything in src.bodyparts)
+	var/affects_leg = FALSE
+	var/stun_time = 0
+	for(var/obj/item/bodypart/L in src.bodyparts)
 		if(!IS_ORGANIC_LIMB(L))
 			if(!informed)
 				to_chat(src, span_userdanger("You feel a sharp pain as your robotic limbs overload."))
 				informed = TRUE
 			switch(severity)
 				if(1)
-					L.receive_damage(0,10)
-					Paralyze(200)
+					L.receive_damage(EMP_BRUTE_DAMAGE, EMP_BURN_DAMAGE_HEAVY)
+					stun_time += 2 SECONDS
 				if(2)
-					L.receive_damage(0,5)
-					Paralyze(100)
+					L.receive_damage(EMP_BRUTE_DAMAGE,EMP_BURN_DAMAGE_LIGHT)
+					stun_time += 1 SECONDS
+			if(L.body_zone == BODY_ZONE_L_LEG || L.body_zone == BODY_ZONE_R_LEG)
+				affects_leg = TRUE
+
+
+			if(L.body_zone == BODY_ZONE_L_ARM || L.body_zone == BODY_ZONE_R_ARM)
+				dropItemToGround(get_item_for_held_index(L.held_index), 1)
+
+	if(stun_time)
+		Paralyze(stun_time)
+	if(affects_leg)
+		switch(severity)
+			if(1)
+				Knockdown(50)
+			if(2)
+				Knockdown(25)
+
+#undef EMP_BRUTE_DAMAGE
+#undef EMP_BURN_DAMAGE_LIGHT
+#undef EMP_BURN_DAMAGE_HEAVY
 
 /mob/living/carbon/human/acid_act(acidpwr, acid_volume, bodyzone_hit) //todo: update this to utilize check_obscured_slots() //and make sure it's check_obscured_slots(TRUE) to stop aciding through visors etc
 	var/list/damaged = list()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Теперь время стана от ЕМП по человеку с робо частями тела будет зависить от числа робо конечностей.

## Why It's Good For The Game

Рейнджовый стан на 20 секунд это кринж

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Время стана от ЕМП для людей с робо частями тела теперь зависит от их количества, а не от факта их присутствия
balance: ЕМП по робо ногам теперь заставляет упасть, а по рукам уранить предмет из них
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
